### PR TITLE
common: git: rename and ignore local .patch extension

### DIFF
--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,1 +1,2 @@
 /Session.vim
+*.git-local.patch

--- a/common/.local/bin/git-llvm-dump-patches
+++ b/common/.local/bin/git-llvm-dump-patches
@@ -4,5 +4,5 @@ count_commits=$(( $(git rev-list --count origin/main..HEAD) - 1))
 
 for c in $(seq 0 "$count_commits"); do
   c_rev="$((count_commits - c))"
-  git show --patch -U99999999 "HEAD~$c" > "$c_rev - $(git rev-parse --short "HEAD~$c") - $(git rev-list --format=%B --max-count=1 "HEAD~$c" | tail +2 | head -n1 | tr '/' '_').patch"
+  git show --patch -U99999999 "HEAD~$c" > "$c_rev - $(git rev-parse --short "HEAD~$c") - $(git rev-list --format=%B --max-count=1 "HEAD~$c" | tail +2 | head -n1 | tr '/' '_').git-local.patch"
 done


### PR DESCRIPTION
A different .patch extension is used to avoid conflicts with real
patches and make them trackable by default.