### PR TITLE
ci(pre-commit): add git diff color configurations for better readability

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,17 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
     - uses: actions/checkout@v3
+    - name: Configure Git
+      run: |
+        git config --global color.diff.meta       "11"
+        git config --global color.diff.frag       "magenta bold"
+        git config --global color.diff.func       "146 bold"
+        git config --global color.diff.commit     "yellow bold"
+        git config --global color.diff.old        "red bold"
+        git config --global color.diff.new        "green bold"
+        git config --global color.diff.whitespace "red reverse"
+
+        git config --global diff.wsErrorHighlight "all"
     - uses: actions/setup-python@v3.0.0
     - uses: pre-commit/action@v2.0.3
 


### PR DESCRIPTION
This patch introduces some sensible configurations to highlight extra
whitespaces and highlight differences from two very identical lines. That makes
pre-commit `--show-diff-on-failure` option more readable and therefore faster
to discover the issue.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>