### PR TITLE
ci(github): allow before-commit to run on master

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   before-commit:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
     - uses: actions/checkout@v3
     - name: Configure Git
@@ -28,6 +27,8 @@ jobs:
         git config --global diff.wsErrorHighlight "all"
     - uses: actions/setup-python@v3.1.2
     - uses: before-commit/run-action@v2.0.3
+      env:
+        SKIP: no-commit-to-branch
 
   hadolint-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will detected failures on branches that are merged with outdated
checks.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>