### PR TITLE
ci(github): add correct terraform path to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "terraform"
-    directory: "/"
+    directory: "/deploy/terraform/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>