### PR TITLE
ci(github): use prek-action on check workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,19 +10,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  before-commit:
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+  pre-commit:
+    runs-on: ubuntu-latest
     steps:
-      - name: Disable auto CRLF on git clone
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          git config --global core.autocrlf "false"
       - uses: actions/checkout@v4
       - name: Configure Git
         run: |
@@ -38,6 +28,6 @@ jobs:
       - uses: actions/setup-python@v5.1.1
         with:
           python-version: '3.x'
-      - uses: before-commit/run-action@v2.0.3
+      - uses: j178/prek-action@v2
         env:
           SKIP: no-commit-to-branch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified continuous integration checks to run on a single Linux runner.
  * Replaced the prior check action with an updated check action implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->