### PR TITLE
Add opencode and pi-agent to devshell to work on other non-nixos systems

### DIFF
--- a/nix/devshell/bwrap-builder.nix
+++ b/nix/devshell/bwrap-builder.nix
@@ -17,9 +17,10 @@ build_bwrap_args() {
   local session_home=$5
   local default_cwd=$6
   local no_sandbox=$7
-  local passwd_file=$8
-  local group_file=$9
-  local shadow_file=${10}
+  shift 7
+  local passwd_file=$1
+  local group_file=$2
+  local shadow_file=$3
 
   if [[ "$no_sandbox" == "1" ]]; then
     echo "NO_SANDBOX"

--- a/nix/devshell/bwrap-builder.nix
+++ b/nix/devshell/bwrap-builder.nix
@@ -17,6 +17,9 @@ build_bwrap_args() {
   local session_home=$5
   local default_cwd=$6
   local no_sandbox=$7
+  local passwd_file=$8
+  local group_file=$9
+  local shadow_file=${10}
 
   if [[ "$no_sandbox" == "1" ]]; then
     echo "NO_SANDBOX"
@@ -49,6 +52,9 @@ build_bwrap_args() {
 
   args+=(--ro-bind /nix/store /nix/store)
   args+=(--ro-bind /etc/resolv.conf /etc/resolv.conf)
+  args+=(--ro-bind "$passwd_file" /etc/passwd)
+  args+=(--ro-bind "$group_file" /etc/group)
+  args+=(--ro-bind "$shadow_file" /etc/shadow)
   args+=(--proc /proc)
   args+=(--dev /dev)
 

--- a/nix/devshell/default.nix
+++ b/nix/devshell/default.nix
@@ -315,13 +315,28 @@ pkgs.stdenv.mkDerivation {
       exit 0
     fi
 
+    PASSWD_FILE=$(mktemp /tmp/monodots-passwd-XXXXXX)
+    GROUP_FILE=$(mktemp /tmp/monodots-group-XXXXXX)
+    SHADOW_FILE=$(mktemp /tmp/monodots-shadow-XXXXXX)
+    trap "rm -f '$PASSWD_FILE' '$GROUP_FILE' '$SHADOW_FILE'" EXIT
+
+    echo "root:x:0:0:root:/root:/bin/bash" > "$PASSWD_FILE"
+    echo "''${USER:-user}:x:$(id -u):$(id -g)::''${HOME:-/home/user}:/bin/bash" >> "$PASSWD_FILE"
+
+    echo "root:x:0:" > "$GROUP_FILE"
+    echo "$(id -gn):x:$(id -g):" >> "$GROUP_FILE"
+
+    echo "root:!:19647:0:99999:7:::" > "$SHADOW_FILE"
+    echo "''${USER:-user}:!:19647:0:99999:7:::" >> "$SHADOW_FILE"
+
     OS="$(uname -s)"
 
     if [[ "$OS" == "Linux" ]]; then
       if [[ "$NOSANDBOX" -eq 1 ]]; then
         exec "$FHS_ENV"
       else
-        build_bwrap_args ALLOW ALLOW_RO DENY "$NETWORK" "$SESSION_HOME" "$DEFAULT_CWD" "$NOSANDBOX"
+        build_bwrap_args ALLOW ALLOW_RO DENY "$NETWORK" "$SESSION_HOME" "$DEFAULT_CWD" "$NOSANDBOX" \
+          "$PASSWD_FILE" "$GROUP_FILE" "$SHADOW_FILE"
         exec "''${BWRAP_ARGS[@]}" "$FHS_ENV"
       fi
     elif [[ "$OS" == "Darwin" ]]; then

--- a/nix/devshell/fhs-env.nix
+++ b/nix/devshell/fhs-env.nix
@@ -13,6 +13,10 @@ let
     gnused
     gnugrep
     gawk
+    opencode
+    nodejs
+    bun
+    pi-coding-agent
   ];
 
 in


### PR DESCRIPTION
Isolating dependencies of the devshell to avoid inheriting host binaries for opencode and pi-agent. It also fixes an issue with passwd/shadow inside the bwrap sandbox.